### PR TITLE
Fix for current twitch api

### DIFF
--- a/twitch-channel-status.js
+++ b/twitch-channel-status.js
@@ -45,7 +45,7 @@
     // Ask twitch for the status of all channels at once
     $.ajax({
       url: "https://api.twitch.tv/kraken/streams",
-      data: {"clientid": clientid, "channel": Object.keys(channels).join(","), "limit": Object.keys(channels).length},
+      data: {"client-ID": clientid, "channel": Object.keys(channels).join(","), "limit": Object.keys(channels).length},
       cache: false,
       dataType: "jsonp"
     }).done(function (data) {

--- a/twitch-channel-status.js
+++ b/twitch-channel-status.js
@@ -3,7 +3,7 @@
 
 // Create a closure with a reference to our script
 (function (document, $script) {
-  console.log('[twitch-channel-status] robbimu fork - v1.0.7')
+  console.log('[twitch-channel-status] robbimu fork - v1.0.8')
   // Allow customizing the script with various data-* attributes
   var clientid = $script.attr("data-clientid") || false
       attribute = $script.attr("data-attribute") || "data-twitch-channel",
@@ -47,11 +47,10 @@
     $.ajax({
       url: "https://api.twitch.tv/kraken/streams",
       headers: {
-        'Client-ID': 'l01lduyl0cfxlgl45t85qiegau166q'
+        'Client-ID': clientid
       },
-      data: {"channel": Object.keys(channels).join(","), "limit": Object.keys(channels).length},
+      data: JSON.stringify({"channel": Object.keys(channels).join(","), "limit": Object.keys(channels).length}),
       cache: false,
-      dataType: "jsonp"
     }).done(function (data) {
       // We can only handle 100 online channels at a time :(
       if (data.streams.length < data._total) {

--- a/twitch-channel-status.js
+++ b/twitch-channel-status.js
@@ -3,7 +3,7 @@
 
 // Create a closure with a reference to our script
 (function (document, $script) {
-  console.log('[twitch-channel-status] robbimu fork - v1.0.6')
+  console.log('[twitch-channel-status] robbimu fork - v1.0.7')
   // Allow customizing the script with various data-* attributes
   var clientid = $script.attr("data-clientid") || false
       attribute = $script.attr("data-attribute") || "data-twitch-channel",
@@ -46,12 +46,8 @@
     // Ask twitch for the status of all channels at once
     $.ajax({
       url: "https://api.twitch.tv/kraken/streams",
-/*      headers: {
+      headers: {
         'Client-ID': 'l01lduyl0cfxlgl45t85qiegau166q'
-      }, */
-      beforeSend: function (request)
-      {
-        request.setRequestHeader("Client-ID", clientid);
       },
       data: {"channel": Object.keys(channels).join(","), "limit": Object.keys(channels).length},
       cache: false,

--- a/twitch-channel-status.js
+++ b/twitch-channel-status.js
@@ -3,7 +3,7 @@
 
 // Create a closure with a reference to our script
 (function (document, $script) {
-  console.log('[twitch-channel-status] robbimu fork - v1.0.12')
+  console.log('[twitch-channel-status] robbimu fork - v1.0.13')
   // Allow customizing the script with various data-* attributes
   var clientid = $script.attr("data-clientid") || false
       attribute = $script.attr("data-attribute") || "data-twitch-channel",
@@ -47,7 +47,7 @@
     $.ajax({
       type: 'GET',
       url: 'https://api.twitch.tv/kraken/streams',
-      data: `channel=${channels.join(",")}&limit=${channels.length}`,
+      data: `channel=${Object.keys(channels).join(",")}&limit=${Object.keys(channels).length}`,
       headers: {
         'Client-ID': clientid
       }

--- a/twitch-channel-status.js
+++ b/twitch-channel-status.js
@@ -3,6 +3,7 @@
 
 // Create a closure with a reference to our script
 (function (document, $script) {
+  console.log('[twitch-channel-status] robbimu fork - v1.0.6')
   // Allow customizing the script with various data-* attributes
   var clientid = $script.attr("data-clientid") || false
       attribute = $script.attr("data-attribute") || "data-twitch-channel",
@@ -45,13 +46,13 @@
     // Ask twitch for the status of all channels at once
     $.ajax({
       url: "https://api.twitch.tv/kraken/streams",
-      headers: {
+/*      headers: {
         'Client-ID': 'l01lduyl0cfxlgl45t85qiegau166q'
-      },
-/*      beforeSend: function (request)
+      }, */
+      beforeSend: function (request)
       {
         request.setRequestHeader("Client-ID", clientid);
-      }, */
+      },
       data: {"channel": Object.keys(channels).join(","), "limit": Object.keys(channels).length},
       cache: false,
       dataType: "jsonp"

--- a/twitch-channel-status.js
+++ b/twitch-channel-status.js
@@ -13,8 +13,8 @@
 
   // if there is no clientId we cannot function!
   if(!clientid) {
-    console.log('[twitch-channel-status] clientid is now manditory for kraken requests. (see: https://blog.twitch.tv/client-id-required-for-kraken-api-calls-afbb8e95f843#.cxn9jkpgi )')
-    console.log('[twitch-channel-status] the clientid can now be set as a `data-clientid` data attribute on the script tag')
+    console.log('[twitch-channel-status] `Client-ID` is now mandatory for kraken requests. (see: https://blog.twitch.tv/client-id-required-for-kraken-api-calls-afbb8e95f843#.cxn9jkpgi )')
+    console.log('[twitch-channel-status] your `Client-ID` can now be set as a `data-clientid` data attribute on the script tag')
   }
 
   document.refreshTwitchChannelStatuses = function () {
@@ -45,7 +45,11 @@
     // Ask twitch for the status of all channels at once
     $.ajax({
       url: "https://api.twitch.tv/kraken/streams",
-      data: {"Client-ID": clientid, "channel": Object.keys(channels).join(","), "limit": Object.keys(channels).length},
+      beforeSend: function (request)
+      {
+        request.setRequestHeader("Client-ID", clientid);
+      },
+      data: {"channel": Object.keys(channels).join(","), "limit": Object.keys(channels).length},
       cache: false,
       dataType: "jsonp"
     }).done(function (data) {

--- a/twitch-channel-status.js
+++ b/twitch-channel-status.js
@@ -45,7 +45,7 @@
     // Ask twitch for the status of all channels at once
     $.ajax({
       url: "https://api.twitch.tv/kraken/streams",
-      data: {"client-ID": clientid, "channel": Object.keys(channels).join(","), "limit": Object.keys(channels).length},
+      data: {"Client-ID": clientid, "channel": Object.keys(channels).join(","), "limit": Object.keys(channels).length},
       cache: false,
       dataType: "jsonp"
     }).done(function (data) {

--- a/twitch-channel-status.js
+++ b/twitch-channel-status.js
@@ -45,10 +45,13 @@
     // Ask twitch for the status of all channels at once
     $.ajax({
       url: "https://api.twitch.tv/kraken/streams",
-      beforeSend: function (request)
+      headers: {
+        'Client-ID': 'l01lduyl0cfxlgl45t85qiegau166q'
+      },
+/*      beforeSend: function (request)
       {
         request.setRequestHeader("Client-ID", clientid);
-      },
+      }, */
       data: {"channel": Object.keys(channels).join(","), "limit": Object.keys(channels).length},
       cache: false,
       dataType: "jsonp"

--- a/twitch-channel-status.js
+++ b/twitch-channel-status.js
@@ -3,7 +3,7 @@
 
 // Create a closure with a reference to our script
 (function (document, $script) {
-  console.log('[twitch-channel-status] robbimu fork - v1.0.10')
+  console.log('[twitch-channel-status] robbimu fork - v1.0.12')
   // Allow customizing the script with various data-* attributes
   var clientid = $script.attr("data-clientid") || false
       attribute = $script.attr("data-attribute") || "data-twitch-channel",
@@ -45,12 +45,12 @@
 
     // Ask twitch for the status of all channels at once
     $.ajax({
-      url: "https://api.twitch.tv/kraken/streams",
+      type: 'GET',
+      url: 'https://api.twitch.tv/kraken/streams',
+      data: `channel=${channels.join(",")}&limit=${channels.length}`,
       headers: {
         'Client-ID': clientid
-      },
-      data: JSON.stringify({channel: Object.keys(channels).join(","), limit: Object.keys(channels).length}),
-      cache: false,
+      }
     }).done(function (data) {
       // We can only handle 100 online channels at a time :(
       if (data.streams.length < data._total) {

--- a/twitch-channel-status.js
+++ b/twitch-channel-status.js
@@ -3,7 +3,7 @@
 
 // Create a closure with a reference to our script
 (function (document, $script) {
-  console.log('[twitch-channel-status] robbimu fork - v1.0.8')
+  console.log('[twitch-channel-status] robbimu fork - v1.0.9')
   // Allow customizing the script with various data-* attributes
   var clientid = $script.attr("data-clientid") || false
       attribute = $script.attr("data-attribute") || "data-twitch-channel",
@@ -55,6 +55,7 @@
       // We can only handle 100 online channels at a time :(
       if (data.streams.length < data._total) {
         console.warn("refreshTwitchChannelStatuses couldn't load all online channels! Please reduce the number of channels you are trying to check.");
+        console.dir(data.streams)
       }
 
       // Build a hash of who's online for performance

--- a/twitch-channel-status.js
+++ b/twitch-channel-status.js
@@ -3,7 +3,7 @@
 
 // Create a closure with a reference to our script
 (function (document, $script) {
-  console.log('[twitch-channel-status] robbimu fork - v1.0.9')
+  console.log('[twitch-channel-status] robbimu fork - v1.0.10')
   // Allow customizing the script with various data-* attributes
   var clientid = $script.attr("data-clientid") || false
       attribute = $script.attr("data-attribute") || "data-twitch-channel",
@@ -49,7 +49,7 @@
       headers: {
         'Client-ID': clientid
       },
-      data: JSON.stringify({"channel": Object.keys(channels).join(","), "limit": Object.keys(channels).length}),
+      data: JSON.stringify({channel: Object.keys(channels).join(","), limit: Object.keys(channels).length}),
       cache: false,
     }).done(function (data) {
       // We can only handle 100 online channels at a time :(

--- a/twitch-channel-status.js
+++ b/twitch-channel-status.js
@@ -4,11 +4,18 @@
 // Create a closure with a reference to our script
 (function (document, $script) {
   // Allow customizing the script with various data-* attributes
-  var attribute = $script.attr("data-attribute") || "data-twitch-channel",
+  var clientid = $script.attr("data-clientid") || false
+      attribute = $script.attr("data-attribute") || "data-twitch-channel",
       interval = parseInt($script.attr("data-interval")) || false,
       onlineImage = $script.attr("data-online-image") || 'data:image/svg+xml,<?xml version="1.0"?><svg height="20px" viewBox="0 0 20 20" version="1.1" xmlns="http://www.w3.org/2000/svg"><circle cx="10" cy="10" r="8" fill="green"/></svg>',
       offlineImage = $script.attr("data-offline-image") || 'data:image/svg+xml,<?xml version="1.0"?><svg height="20px" viewBox="0 0 20 20" version="1.1" xmlns="http://www.w3.org/2000/svg"><circle cx="10" cy="10" r="8" fill="red"/></svg>',
       minInterval = 30; // seconds
+
+  // if there is no clientId we cannot function!
+  if(!clientid) {
+    console.log('[twitch-channel-status] clientid is now manditory for kraken requests. (see: https://blog.twitch.tv/client-id-required-for-kraken-api-calls-afbb8e95f843#.cxn9jkpgi )')
+    console.log('[twitch-channel-status] the clientid can now be set as a `data-clientid` data attribute on the script tag')
+  }
 
   document.refreshTwitchChannelStatuses = function () {
     var channels = {};
@@ -38,7 +45,7 @@
     // Ask twitch for the status of all channels at once
     $.ajax({
       url: "https://api.twitch.tv/kraken/streams",
-      data: {"channel": Object.keys(channels).join(","), "limit": Object.keys(channels).length},
+      data: {"clientid": clientid, "channel": Object.keys(channels).join(","), "limit": Object.keys(channels).length},
       cache: false,
       dataType: "jsonp"
     }).done(function (data) {

--- a/twitch-channel-status.js
+++ b/twitch-channel-status.js
@@ -3,7 +3,7 @@
 
 // Create a closure with a reference to our script
 (function (document, $script) {
-  console.log('[twitch-channel-status] robbimu fork - v1.0.13')
+  console.log('[twitch-channel-status] robbimu fork - v1.0.14')
   // Allow customizing the script with various data-* attributes
   var clientid = $script.attr("data-clientid") || false
       attribute = $script.attr("data-attribute") || "data-twitch-channel",
@@ -77,6 +77,7 @@
           var $img = imgs[i];
           var src = $img.attr("data-" + (online ? "online" : "offline") + "-image") || image;
           $img.attr("src", src);
+          online? $img.addClass('online'):$img.removeClass('online')
         }
       }
 


### PR DESCRIPTION
this only fixes the unminified version.

for an overview of the core issue, see: https://blog.twitch.tv/client-id-required-for-kraken-api-calls-afbb8e95f843#.cxn9jkpgi

the reason you can't just use a 'header' or 'beforeSend' to attach the Client-ID is because it was a `jsonp` query, which makes a ghost `<script>` tag who can't take modified headers. So.. I manually backed it out of jsonp.

you would use it like: 

```
<script src="https://cdn.rawgit.com/robbiemu/Twitch-Channel-Status/master/twitch-channel-status.js" data-clientid="_TWITCH_CLIENT_ID_"></script>
```

After merging, you might change the console log messages to suit the project. I _do believe_ that at least 2 of the three of them are important :)